### PR TITLE
1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.1](https://github.com/Okipa/laravel-brickables/compare/1.0.0...1.0.1)
+
+2020-02-20
+
+* Fixed the wrong bricks order returned by the `Brickables::castBricks()` method.
+
 ## [1.0.0](https://github.com/Okipa/laravel-brickables/compare/1.0.0...1.0.0)
 
 2020-02-14

--- a/src/Brickables.php
+++ b/src/Brickables.php
@@ -132,10 +132,11 @@ class Brickables implements Htmlable
                 return $brick->getAttributes();
             })->toArray();
             $castedBricks = $model->hydrate($brickableBricksDataArray);
+            $castedBricks = $castedBricks->sortBy($model->sortable['order_column_name']);
             $casted->push($castedBricks);
         }
 
-        return $casted->flatten()->sortBy($model->sortable['order_column_name']);
+        return $casted->flatten();
     }
 
     /**

--- a/src/Brickables.php
+++ b/src/Brickables.php
@@ -119,6 +119,9 @@ class Brickables implements Htmlable
      */
     public function castBricks(Collection $bricks): Collection
     {
+        if ($bricks->isEmpty()) {
+            return $bricks;
+        }
         $casted = new Collection;
         foreach ($bricks->pluck('brickable_type')->unique() as $brickableClass) {
             /** @var \Okipa\LaravelBrickables\Abstracts\Brickable $brickable */
@@ -132,7 +135,7 @@ class Brickables implements Htmlable
             $casted->push($castedBricks);
         }
 
-        return $casted->flatten();
+        return $casted->flatten()->sortBy($model->sortable['order_column_name']);
     }
 
     /**


### PR DESCRIPTION
* Fixed the wrong bricks order returned by the `Brickables::castBricks()` method.

Fixes https://github.com/Okipa/laravel-brickables/issues/3